### PR TITLE
Fix missing tag event calling

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -18,8 +18,8 @@ return PhpCsFixer\Config::create()
                                             'This source file is available under following license:' . PHP_EOL .
                                             '- GNU General Public License v3.0 (GNU GPLv3)' . PHP_EOL .
                                             PHP_EOL .
-                                            ' @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)' . PHP_EOL .
-                                            ' @license    https://www.gnu.org/licenses/gpl-3.0.txt'
+                                            '@copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)' . PHP_EOL .
+                                            '@license    https://www.gnu.org/licenses/gpl-3.0.txt'
                                     ],
 
         // keep aligned = and => operators as they are: do not force aligning, but do not remove it

--- a/src/BatchOperationBundle.php
+++ b/src/BatchOperationBundle.php
@@ -6,8 +6,8 @@
  * This source file is available under following license:
  * - GNU General Public License v3.0 (GNU GPLv3)
  *
- *  @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
- *  @license    https://www.gnu.org/licenses/gpl-3.0.txt
+ * @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.txt
  */
 
 namespace Studio1\BatchOperationBundle;

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -6,8 +6,8 @@
  * This source file is available under following license:
  * - GNU General Public License v3.0 (GNU GPLv3)
  *
- * @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
- * @license    https://www.gnu.org/licenses/gpl-3.0.txt
+ *  @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
+ *  @license    https://www.gnu.org/licenses/gpl-3.0.txt
  */
 
 namespace Studio1\BatchOperationBundle\Controller;

--- a/src/Controller/DefaultController.php
+++ b/src/Controller/DefaultController.php
@@ -6,8 +6,8 @@
  * This source file is available under following license:
  * - GNU General Public License v3.0 (GNU GPLv3)
  *
- *  @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
- *  @license    https://www.gnu.org/licenses/gpl-3.0.txt
+ * @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.txt
  */
 
 namespace Studio1\BatchOperationBundle\Controller;

--- a/src/DependencyInjection/BatchOperationExtension.php
+++ b/src/DependencyInjection/BatchOperationExtension.php
@@ -6,8 +6,8 @@
  * This source file is available under following license:
  * - GNU General Public License v3.0 (GNU GPLv3)
  *
- *  @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
- *  @license    https://www.gnu.org/licenses/gpl-3.0.txt
+ * @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.txt
  */
 
 namespace Studio1\BatchOperationBundle\DependencyInjection;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -6,8 +6,8 @@
  * This source file is available under following license:
  * - GNU General Public License v3.0 (GNU GPLv3)
  *
- *  @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
- *  @license    https://www.gnu.org/licenses/gpl-3.0.txt
+ * @copyright  Copyright (c) Studio1 Kommunikation GmbH (http://www.studio1.de)
+ * @license    https://www.gnu.org/licenses/gpl-3.0.txt
  */
 
 namespace Studio1\BatchOperationBundle\DependencyInjection;


### PR DESCRIPTION
Fix issue:
``Tag::batchAssignTagsToElement`` and ``Tag::setTagsForElement`` don't use pimcore tag events and tag event listener is not working (listening for ``pimcore.tag.postAddToElement``or ``pimcore.tag.postRemoveFromElement``has no effect)